### PR TITLE
fix: incorrect defaulted values

### DIFF
--- a/src/p1.js
+++ b/src/p1.js
@@ -7,11 +7,11 @@ logger.add(new logger.transports.Console({
 }))
 
 /**
- * 1: Goto: http://developer.athom.com
+ * 1: Go to: https://tools.developer.homey.app/
  * 2: Login into Homey
- * 3: Open the inspector (chrome f12)
+ * 3: Open the inspector (Chrome f12)
  * 4: Click the `network` tab
- * 5: Refresh the page (you see couple of webpages being called)
+ * 5: Open the "Tools" > "System" page
  * 6: Copy the `homeyId` from the url: https://[localId].homey.homeylocal.com/api/manager/system/ping?id=[homeyId]
  */
 const homeyId = '5c....................23'
@@ -93,29 +93,29 @@ function publishToHomey (output) {
         'power': {
           'positive': {
             'L1': {
-              'reading': output.power.instantaneousConsumedElectricityL1 || output.power.actualConsumed || 0,
+              'reading': getDefaultedValue(output.power.instantaneousConsumedElectricityL1, output.power.actualConsumed),
               'unit': 'kW',
             },
             'L2': {
-              'reading': output.power.instantaneousConsumedElectricityL2 || 0,
+              'reading': getDefaultedValue(output.power.instantaneousConsumedElectricityL2),
               'unit': 'kW',
             },
             'L3': {
-              'reading': output.power.instantaneousConsumedElectricityL3 || 0,
+              'reading': getDefaultedValue(output.power.instantaneousConsumedElectricityL3),
               'unit': 'kW',
             },
           },
           'negative': {
             'L1': {
-              'reading': output.power.instantaneousProducedElectricityL1 || output.power.actualProduced || 0,
+              'reading': getDefaultedValue(output.power.instantaneousProducedElectricityL1, output.power.actualProduced),
               'unit': 'kW',
             },
             'L2': {
-              'reading': output.power.instantaneousProducedElectricityL2 || 0,
+              'reading': getDefaultedValue(output.power.instantaneousProducedElectricityL2),
               'unit': 'kW',
             },
             'L3': {
-              'reading': output.power.instantaneousProducedElectricityL3 || 0,
+              'reading': getDefaultedValue(output.power.instantaneousProducedElectricityL3),
               'unit': 'kW',
             },
           },
@@ -152,6 +152,15 @@ function publishToHomey (output) {
             logger.error(error)
         })
     }
+}
+
+function getDefaultedValue(...args) {
+  for (let arg of args) {
+    if (arg !== undefined) {
+      return arg;
+    }
+  }
+  return 0;
 }
 
 const p1Meter = new dsmr({


### PR DESCRIPTION
# Fix for incorrectly defaulted values

## Summary
This pull request addresses an issue related to the reporting of electricity consumption and production values for triple-phase power.

## Context
After installing a new power meter, I transitioned from single-phase to triple-phase power. However, the existing reader began reporting incorrect values. The issue arises from a unique edge-case scenario: most of my home is connected to the first phase, while solar panels are connected to the second phase. This results in power consumption on the first phase and power generation on the second phase.

## Problem
The discrepancy occurs in the calculation of `electricity.instantaneous.power.negative.L1` due to the defaulting behavior of `output.power.instantaneousProducedElectricityL1`:

```node
output.power.instantaneousProducedElectricityL1 || output.power.actualProduced || 0,
```

This defaulting behavior should only apply when `output.power.instantaneousProducedElectricityL1` is `undefined`, not when it is `0`.

## Solution
A new function `getDefaultedValue` has been introduced to handle the defaulting behavior. It iterates through provided arguments and returns the first non-undefined value or 0 if all provided arguments are undefined:

```node
function getDefaultedValue(...args) {
  for (let arg of args) {
    if (arg !== undefined) {
      return arg;
    }
  }
  return 0;
}
```

## Example
```node
const output = {
  power: {
    actualProduced: 123,
    instantaneousProducedElectricityL1: 0
  }
}

// Incorrectly outputs 123
console.log(output.power.instantaneousProducedElectricityL1 || output.power.actualProduced || 0)

// Correctly outputs 0 
console.log(getDefaultedValue(output.power.instantaneousProducedElectricityL1, output.power.actualProduced))
```

This change ensures that the defaulting behavior operates as intended, addressing the reported discrepancies.